### PR TITLE
feat: Add user management with SQLite and API

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,85 @@
-const express = require("express");
+const express = require('express');
 const app = express();
+// Ensure database is initialized
+const db = require('./database.js'); 
+const userService = require('./userService.js');
+
+app.use(express.json()); // Middleware to parse JSON bodies
+
+// Add a new user
+app.post('/users', async (req, res) => {
+    const { username, email, password } = req.body;
+    if (!username || !email || !password) {
+        return res.status(400).json({ error: 'Username, email, and password are required.' });
+    }
+    try {
+        const newUser = await userService.addUser(username, email, password);
+        res.status(201).json(newUser);
+    } catch (err) {
+        console.error("Error adding user:", err);
+        if (err.message.includes('UNIQUE constraint failed')) {
+            return res.status(409).json({ error: 'Username or email already exists.' });
+        }
+        res.status(500).json({ error: 'Failed to add user.' });
+    }
+});
+
+// Get a user by ID
+app.get('/users/:id', async (req, res) => {
+    const { id } = req.params;
+    try {
+        const user = await userService.getUserById(parseInt(id));
+        if (user) {
+            res.json(user);
+        } else {
+            res.status(404).json({ error: 'User not found.' });
+        }
+    } catch (err) {
+        console.error(`Error getting user ${id}:`, err);
+        res.status(500).json({ error: 'Failed to get user.' });
+    }
+});
+
+// Update a user
+app.put('/users/:id', async (req, res) => {
+    const { id } = req.params;
+    const { email, password } = req.body;
+
+    if (!email && !password) {
+        return res.status(400).json({ error: 'Email or password is required for update.' });
+    }
+
+    try {
+        const result = await userService.updateUser(parseInt(id), { email, password });
+        if (result) {
+            res.json({ message: `User ${id} updated successfully.`, changes: result.changes });
+        } else {
+            res.status(404).json({ error: 'User not found or no changes made.' });
+        }
+    } catch (err) {
+        console.error(`Error updating user ${id}:`, err);
+         if (err.message.includes('UNIQUE constraint failed')) {
+            return res.status(409).json({ error: 'Email already exists.' });
+        }
+        res.status(500).json({ error: 'Failed to update user.' });
+    }
+});
+
+// Delete a user
+app.delete('/users/:id', async (req, res) => {
+    const { id } = req.params;
+    try {
+        const result = await userService.deleteUser(parseInt(id));
+        if (result) {
+            res.json({ message: `User ${id} deleted successfully.`, deleted: result.deleted });
+        } else {
+            res.status(404).json({ error: 'User not found.' });
+        }
+    } catch (err) {
+        console.error(`Error deleting user ${id}:`, err);
+        res.status(500).json({ error: 'Failed to delete user.' });
+    }
+});
 
 app.get("/test", (req, res) => res.json({ ok: true }));
 

--- a/database.js
+++ b/database.js
@@ -1,0 +1,29 @@
+const sqlite3 = require('sqlite3').verbose();
+const DBSOURCE = "users.db";
+
+const db = new sqlite3.Database(DBSOURCE, (err) => {
+    if (err) {
+        // Cannot open database
+        console.error(err.message);
+        throw err;
+    } else {
+        console.log('Connected to the SQLite database.');
+        db.run(`CREATE TABLE IF NOT EXISTS users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            username TEXT UNIQUE NOT NULL,
+            email TEXT UNIQUE NOT NULL,
+            password_hash TEXT NOT NULL,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        )`, (err) => {
+            if (err) {
+                // Table already created or other error
+                console.error("Error creating users table:", err.message);
+            } else {
+                // Table just created or already exists
+                console.log("Users table ready.");
+            }
+        });
+    }
+});
+
+module.exports = db;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   },
   "author": "pg1",
   "dependencies": {
-    "express": "4.0.0"
+    "express": "4.0.0",
+    "sqlite3": "^5.1.7",
+    "bcrypt": "^5.1.1"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/userService.js
+++ b/userService.js
@@ -1,0 +1,104 @@
+const db = require('./database.js');
+const bcrypt = require('bcrypt');
+const saltRounds = 10; // Standard practice for bcrypt
+
+const userService = {
+    addUser: (username, email, password) => {
+        return new Promise((resolve, reject) => {
+            bcrypt.hash(password, saltRounds, (err, hash) => {
+                if (err) {
+                    return reject(err);
+                }
+                const sql = 'INSERT INTO users (username, email, password_hash) VALUES (?, ?, ?)';
+                const params = [username, email, hash];
+                db.run(sql, params, function(err) {
+                    if (err) {
+                        return reject(err);
+                    }
+                    resolve({ id: this.lastID, username, email });
+                });
+            });
+        });
+    },
+
+    getUserById: (id) => {
+        return new Promise((resolve, reject) => {
+            const sql = "SELECT id, username, email, created_at FROM users WHERE id = ?";
+            db.get(sql, [id], (err, row) => {
+                if (err) {
+                    return reject(err);
+                }
+                resolve(row);
+            });
+        });
+    },
+
+    getUserByUsername: (username) => {
+        return new Promise((resolve, reject) => {
+            const sql = "SELECT id, username, email, created_at FROM users WHERE username = ?";
+            db.get(sql, [username], (err, row) => {
+                if (err) {
+                    return reject(err);
+                }
+                resolve(row);
+            });
+        });
+    },
+
+    updateUser: (id, { email, password }) => {
+        return new Promise(async (resolve, reject) => {
+            if (!email && !password) {
+                return reject(new Error("No fields to update (email or password required)."));
+            }
+
+            let sql = 'UPDATE users SET ';
+            const params = [];
+            const setClauses = [];
+
+            if (email) {
+                setClauses.push('email = ?');
+                params.push(email);
+            }
+
+            if (password) {
+                try {
+                    const hash = await bcrypt.hash(password, saltRounds);
+                    setClauses.push('password_hash = ?');
+                    params.push(hash);
+                } catch (err) {
+                    return reject(err);
+                }
+            }
+
+            sql += setClauses.join(', ') + ' WHERE id = ?';
+            params.push(id);
+
+            db.run(sql, params, function(err) {
+                if (err) {
+                    return reject(err);
+                }
+                if (this.changes === 0) {
+                    return resolve(null); // No user found or no changes made
+                }
+                resolve({ id, changes: this.changes });
+            });
+        });
+    },
+
+    deleteUser: (id) => {
+        return new Promise((resolve, reject) => {
+            const sql = 'DELETE FROM users WHERE id = ?';
+            db.run(sql, [id], function(err) {
+                if (err) {
+                    return reject(err);
+                }
+                if (this.changes === 0) {
+                    return resolve(null); // No user found
+                }
+                resolve({ id, deleted: this.changes });
+            });
+        });
+    }
+};
+
+module.exports = userService;


### PR DESCRIPTION
This commit introduces user management functionality:

- **Database**: Initializes an SQLite database (`users.db`) with a `users` table (id, username, email, password_hash, created_at).
- **User Service**: `userService.js` provides CRUD operations for users, including password hashing using bcrypt.
- **API Endpoints**:
    - `POST /users`: Creates a new user.
    - `GET /users/:id`: Retrieves a user by ID.
    - `PUT /users/:id`: Updates a user's email or password.
    - `DELETE /users/:id`: Deletes a user.
- **Dependencies**: Adds `sqlite3` and `bcrypt` to `package.json`.

**Note on Testing**:
`npm install` commands repeatedly timed out in the development environment. Consequently, the new dependencies (`sqlite3`, `bcrypt`) may not be installed in the current environment snapshot, and I couldn't run the application to test the new API endpoints. I recommend you conduct thorough testing in an environment where `npm install` can complete successfully and the application can be started.