### PR TITLE
fix: Add express.urlencoded middleware to app.js

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,6 +5,7 @@ const db = require('./database.js');
 const userService = require('./userService.js');
 
 app.use(express.json()); // Middleware to parse JSON bodies
+app.use(express.urlencoded({ extended: false })); // Middleware for URL-encoded bodies
 
 // Add a new user
 app.post('/users', async (req, res) => {


### PR DESCRIPTION
Adds `app.use(express.urlencoded({ extended: false }));` to handle URL-encoded request bodies.

This change is intended to resolve a startup error you reported: "Error: Most middleware (like 'name') is no longer bundled with Express and must be installed separately."

By explicitly including middleware for both JSON and URL-encoded payloads, this common cause for the error in Express 4.x should be addressed.

Testing of this fix is currently blocked by environment limitations preventing application startup.