### PR TITLE
Fix: Correct database path and add initial test

### DIFF
--- a/database.ts
+++ b/database.ts
@@ -1,11 +1,14 @@
 import sqlite3 from 'sqlite3';
-import path from 'path'; // Will be used if DBSOURCE needs __dirname later
+import path from 'path';
+import { fileURLToPath } from 'url';
 
-// Determine the correct path to users.db. 
-// If users.db is in the root, this is fine. 
-// If this script is run from ./dist after compilation, path might need adjustment
-// For now, assume users.db is in the project root.
-const DBSOURCE = "users.db"; 
+// Derive __dirname in ES module scope
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// DBSOURCE is constructed to point to users.db in the project root,
+// assuming this script (database.ts) is compiled into the 'dist' directory.
+const DBSOURCE = path.join(__dirname, '..', 'users.db');
 
 // Use verbose for more detailed error messages
 const verboseSqlite3 = sqlite3.verbose();

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -1,0 +1,35 @@
+const assert = require('assert');
+// Assuming app.ts compiles to dist/app.js and exports the fastify instance as default
+const fastify = require('../dist/app.js').default;
+
+async function runTest() {
+    try {
+        // Start the server on an available port
+        await fastify.listen({ port: 0 });
+        const port = fastify.server.address().port;
+
+        // Make a request to the /test endpoint
+        const response = await fetch(`http://localhost:${port}/test`);
+
+        // Check the status code
+        assert.strictEqual(response.status, 200, `Expected status 200, got ${response.status}`);
+
+        // Check the response body
+        const body = await response.json();
+        assert.deepStrictEqual(body, { ok: true }, `Expected body { ok: true }, got ${JSON.stringify(body)}`);
+
+        console.log('Test /test endpoint passed successfully!');
+
+    } catch (err) {
+        console.error('Test /test endpoint failed:', err);
+        process.exitCode = 1; // Indicate test failure
+    } finally {
+        // Ensure the server is closed
+        if (fastify && fastify.server && fastify.server.listening) {
+            await fastify.close();
+            console.log('Server closed.');
+        }
+    }
+}
+
+runTest();


### PR DESCRIPTION
The SQLite database path in `database.ts` was previously set to a relative path ("users.db") which would likely fail when the application is compiled to a `dist/` directory and run from there. This change updates the path to be `path.join(__dirname, '..', 'users.db')`, ensuring it correctly locates or creates the `users.db` file in the project root. ESM-compatible `__dirname` derivation was also added to `database.ts`.

Additionally, a basic test file `test/app.test.js` was created. This test programmatically starts the Fastify server, makes a request to the `/test` endpoint, and verifies the response. This provides an initial check for server functionality.

These changes aim to resolve potential startup issues related to database connectivity and provide a basic test harness.